### PR TITLE
resetting the available list each time on source update to properly d…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ app/**/*.js.map
 node_modules
 typings
 **~
+.idea/

--- a/app/dual-list.component.ts
+++ b/app/dual-list.component.ts
@@ -115,6 +115,7 @@ export class DualListComponent implements OnChanges {
 		}
 
 		if (changeRecord['source']) {
+            this.available = new BasicList(DualListComponent.AVAILABLE_LIST_NAME);
 			if (this.source !== undefined) {
 				this.source.filter( (e:any) => {
 					this.available.list.push( { _id: e[this.key], _name: this.makeName(e) });


### PR DESCRIPTION
With reactive data sources (e.g. in meteor) if the list is changed, then the component shows duplicate items(the redundant items are not draggable, yet they appear in the source list).
Check out this screenshot: http://i.imgur.com/ey059OS.png

The list was proper initially but as soon as I inserted some data via meteor mongo, due to reactivity, the source list changed and this caused the list to show duplicate items. 
Applying the simple fix as in this commit fixed the issue. 

I have not completely analyzed the code, so do review it and merge if you find appropriate.
